### PR TITLE
Add MaterialAdmin support

### DIFF
--- a/scripting/stac.sp
+++ b/scripting/stac.sp
@@ -15,7 +15,8 @@
 #include <autoexecconfig>
 #undef REQUIRE_PLUGIN
 #include <updater>
-#include <sourcebanspp>
+#tryinclude <sourcebanspp>
+#tryinclude <materialadmin>
 #include <discord>
 #undef REQUIRE_EXTENSIONS
 #include <steamtools>

--- a/scripting/stac/stac_globals.sp
+++ b/scripting/stac/stac_globals.sp
@@ -94,6 +94,7 @@ float timeSinceLagSpike;
 
 // native/gamemode/plugin etc bools
 bool SOURCEBANS;
+bool MATERIALADMIN;
 bool GBANS;
 bool STEAMTOOLS;
 bool STEAMWORKS;

--- a/scripting/stac/stac_mapchange.sp
+++ b/scripting/stac/stac_mapchange.sp
@@ -72,6 +72,11 @@ Action checkNativesEtc(Handle timer)
     {
         SOURCEBANS = true;
     }
+    // materialadmin
+    if (GetFeatureStatus(FeatureType_Native, "MABanPlayer") == FeatureStatus_Available)
+    {
+        MATERIALADMIN = true;
+    }
     // gbans
     if (CommandExists("gb_ban"))
     {

--- a/scripting/stac/stac_stocks.sp
+++ b/scripting/stac/stac_stocks.sp
@@ -348,12 +348,16 @@ void BanUser(int userid, char[] reason, char[] pubreason)
             StacLog("[StAC] No STV demo is being recorded, no demo name will be printed to the ban reason!");
         }
     }
-    if (isAuthed)
+    if (isAuthed) // TODO: Remove hardcoded ban duration (0)
     {
         if (SOURCEBANS)
         {
             SBPP_BanPlayer(0, Cl, 0, reason);
             // there's no return value for that native, so we have to just assume it worked lol
+            return;
+        }
+        if (MATERIALADMIN && MABanPlayer(0, Cl, MA_BAN_STEAM, 0, reason))
+        {
             return;
         }
         if (GBANS)


### PR DESCRIPTION
Also, you probably should rewrite `checkNativesEtc()` (and other **optional** code) and use these: `LibraryExists()`, `OnLibraryAdded()` and `OnLibraryRemoved()` instead of `GetFeatureStatus()`.

I usually do optional code like this:
```sourcepawn
#undef REQUIRE_PLUGIN
#tryinclude <sourcebanspp>
#tryinclude <materialadmin>
#define REQUIRE_PLUGIN

#if defined _sourcebanspp_included
bool g_bSBPP = false;
#endif

#if defined _materialadmin_included
bool g_bMA = false;
#endif

public void OnPluginStart() {
	// ...

	// Late-load support

#if defined _sourcebanspp_included
	g_bSBPP = LibraryExists( "sourcebans++" );
#endif

#if defined _materialadmin_included
	g_bMA = LibraryExists( "materialadmin" );
#endif
}

public void OnLibraryAdded(const char[] name) {
#if defined _sourcebanspp_included
	if ( StrEqual( name, "sourcebans++" ) ) {
		g_bSBPP = true;
		return;
	}
#endif

#if defined _materialadmin_included
	if ( StrEqual( name, "materialadmin" ) ) {
		g_bMA = true;
		return;
	}
#endif

	// and so on ...
}
public void OnLibraryRemoved(const char[] name) {
#if defined _sourcebanspp_included
	if ( StrEqual( name, "sourcebans++" ) ) {
		g_bSBPP = false;
		return;
	}
#endif

#if defined _materialadmin_included
	if ( StrEqual( name, "materialadmin" ) ) {
		g_bMA = false;
		return;
	}
#endif

	// and so on ...
}

#if defined _sourcebanspp_included
public void SBPP_OnBanPlayer(int iAdmin, int iTarget, int iTime, const char[] sReason) {
	// ...
}
#endif

#if defined _materialadmin_included
public void MAOnClientBanned(int iClient, int iTarget, char[] sIp, char[] sSteamID, char[] sName, int iTime, char[] sReason) {
	// ...
}
#endif
```
I know that this way you have to write more code, but this method allows you to compile with/without additional includes and doesn't add to the plugin binary everything (variables, forwards, natives etc.) that was not included (works like **stock** functions but you have to add `#if defined ...` manually).

Then you can use it in functions like `BanUser`:
```sourcepawn
#if defined _sourcebanspp_included
		if ( g_bSBPP ) {
			SBPP_BanPlayer( 0, Cl, 0, reason );
			// there's no return value for that native, so we have to just assume it worked lol
			return;
		}
#endif

#if defined _materialadmin_included
		if ( g_bMA && MABanPlayer( 0, Cl, MA_BAN_STEAM, 0, reason ) )
			return;
#endif
```
