### PR TITLE
Add missing translations for newlineBanMsg

### DIFF
--- a/scripting/stac/stac_misc_checks.sp
+++ b/scripting/stac/stac_misc_checks.sp
@@ -117,7 +117,7 @@ Action BanName(Handle timer, int userid)
         char reason[128];
         Format(reason, sizeof(reason), "%t", "illegalNameBanMsg");
         char pubreason[256];
-        Format(pubreason, sizeof(pubreason), "%t", "illegalNameBanMsg", Cl);
+        Format(pubreason, sizeof(pubreason), "%t", "illegalNameBanAllChat", Cl);
         BanUser(userid, reason, pubreason);
     }
     else

--- a/translations/stac.phrases.txt
+++ b/translations/stac.phrases.txt
@@ -398,4 +398,15 @@
         "es"        "{hotpink}[StAC]{mediumpurple}El Interp{white} del jugador {1}'s era {mediumpurple}{2}{white}ms, indicios de interp exploitation. {palegreen}Expulsado del servidor."
         "de"        "{hotpink}[StAC]{white} Spieler {1}'s {mediumpurple}interp{white} war {mediumpurple}{2}{white}ms, weist auf interp Manipulation hin. {palegreen}Vom Server gekickt."
     }
+    "newlineBanMsg"
+    {
+        "en"    "[StAC] Banned for using illegal characters in chat"
+        "es"    "[StAC] Baneado por caracteres no permitidos en la charla"
+    }
+    "newlineBanAllChat"
+    {
+        "#format"   "{1:N}"
+        "en"        "{hotpink}[StAC]{white} Player {1} used {mediumpurple}illegal characters{white} in the chat! {palegreen}BANNED from server!"
+        "es"        "{hotpink}[StAC]{white} El jugador {1} usó {mediumpurple}caracteres no permitidos{white} en la charla! {palegreen}BANEADO del servidor!"
+    }
 }


### PR DESCRIPTION
```
L 08/25/2022 - 19:16:02: [SM] Exception reported: Language phrase "newlineBanMsg" not found (arg 5)
L 08/25/2022 - 19:16:02: [SM] Blaming: stac.smx
L 08/25/2022 - 19:16:02: [SM] Call stack trace:
L 08/25/2022 - 19:16:02: [SM]   [0] Format
L 08/25/2022 - 19:16:02: [SM]   [1] Line 26, stac/stac_misc_checks.sp::OnClientSayCommand
```
This getting spammed in my error logs and turns out there's no translation for it. I only know Spanish in addition to English so that's all I could do.

Also, illegalCharacterInName was using the wrong translation for printing to allchat so that probably would've had an error as well.