### PR TITLE
Invisible RegConsoleCmd

### DIFF
--- a/scripting/stac.sp
+++ b/scripting/stac.sp
@@ -121,7 +121,6 @@ public void OnPluginStart()
     }
 
     // reg admin commands
-    // TODO: make these invisible for non admins
     RegConsoleCmd("sm_stac_checkall",   checkAdmin, "Force check all client convars (ALL CLIENTS) for anticheat stuff");
     RegConsoleCmd("sm_stac_detections", checkAdmin, "Show all current detections on all connected clients");
     RegConsoleCmd("sm_stac_getauth",    checkAdmin, "Print StAC's cached auth for a client");

--- a/scripting/stac/stac_commands.sp
+++ b/scripting/stac/stac_commands.sp
@@ -24,7 +24,7 @@ Action checkAdmin(int callingCl, int args)
             char fmtmsg[512];
             Format(fmtmsg, sizeof(fmtmsg), "Client %N attempted to use %s, blocked access!", callingCl, arg0);
             StacNotify(GetClientUserId(callingCl), fmtmsg);
-            return Plugin_Handled;
+            return Plugin_Continue;
         }
     }
 


### PR DESCRIPTION
Hide `sm_stac_checkall`, `sm_stac_detections`, `sm_stac_getauth`, `sm_stac_livefeed` from client, normally when a command doesn't exist, they will get "Unknown command" in the console. But since using `Plugin_Handled`, it returns nothing instead of erroring out. If we convert it to `Plugin_Continue`, it will show "Unknown command" client side.

These should also be converted to AddCommandListener, but that can be done later if you want.

Side note, these notifications can be used to spam the server with logs, not sure if you want to log every time someone hits them.

https://github.com/sapphonie/StAC-tf2/blob/51b3eb3862331e428c90234f491a951a6c638375/scripting/stac/stac_commands.sp#L22-L26