### PR TITLE
Fix detection for SMAC core and module plugins

### DIFF
--- a/scripting/stac.sp
+++ b/scripting/stac.sp
@@ -283,7 +283,7 @@ void StopIncompatPlugins()
         }
         else if
         (
-                StrContains(plName, "SMAC", false) == 0
+                StrContains(plName, "SMAC ", false) == 0
                 || StrEqual(plName, "SourceMod Anti-Cheat", false)
         ) /* SMAC */
         {

--- a/scripting/stac.sp
+++ b/scripting/stac.sp
@@ -281,7 +281,11 @@ void StopIncompatPlugins()
             SetFailState("[StAC] Refusing to load with malicious plugins.");
             return;
         }
-        else if (StrContains(plName, "SMAC", false) != -1) /* SMAC */
+        else if
+        (
+                StrContains(plName, "SMAC", false) == 0
+                || StrEqual(plName, "SourceMod Anti-Cheat", false)
+        ) /* SMAC */
         {
             delete plugini;
             SetFailState("[StAC] Refusing to load with SMAC. SMAC is outdated and is actively harmful to server performance as well as StAC's operation. Uninstall SMAC and try again.");


### PR DESCRIPTION
Fix for #198

All the official SMAC stuff starts with "SMAC " (with trailing space) except for the core plugin which is "SourceMod Anti-Cheat"
Not sure if there's and "[SMAC]" variants out there or not ¯\\\_(ツ)_/¯