### PR TITLE
ignore snaps on higher ping clients that are smaller than 2.5 degrees

### DIFF
--- a/scripting/stac/stac_onplayerruncmd.sp
+++ b/scripting/stac/stac_onplayerruncmd.sp
@@ -722,6 +722,15 @@ void psilentCheck(int cl)
     {
         return;
     }
+
+    // high ping clients seem far more likely to produce bunk detections. probably related to interp, i dunno, i don't care
+    // require a bigger snap before counting these ppls snaps as detections
+    // Why 205? it's slightly bigger than what we set sv_maxunlag to :smilecat:
+    if (pingFor[cl] >= 205.0 && aDiffReal <= 2.5)
+    {
+        return;
+    }
+
     int userid = GetClientUserId(cl);
     pSilentDetects[cl]++;
     // have this detection expire in 30 minutes


### PR DESCRIPTION
as far as i can tell once we get above sv_maxunlag things can get a little funny with interp and packet reordering, so i would rather be safe than sorry here.

the alternative is disabling fuzzy checks on these clients, that's probably better, but i don't want to take any chances. if someone with >= 200 ping has gotten banned on your server by stac for psilent detects and has complained and repeatedly denied that they are cheating, you should probably unban them.