### PR TITLE
fix: pass non-empty command to BanClient so external ban systems (e.g. SQLiteBans) can record the ban

### DIFF
--- a/scripting/stac/stac_stocks.sp
+++ b/scripting/stac/stac_stocks.sp
@@ -470,7 +470,10 @@ void BanUser(int userid, char reason[128], char pubreason[256])
             return;
         }
         // stock tf2, no ext ban system. if we somehow fail here, keep going.
-        if (BanClient(cl, banDuration, BANFLAG_AUTO, reason, reason, _, _))
+        // command MUST be non-empty: if it's empty, SourceMod won't fire the
+        // OnBanClient forward, so ban systems that hook it (e.g. SQLiteBans)
+        // will never see/record this ban.
+        if (BanClient(cl, banDuration, BANFLAG_AUTO, reason, reason, "stac", _))
         {
             return;
         }


### PR DESCRIPTION
### Problem

StAC's auto-bans kick players but are never recorded by external ban systems like SQLiteBans. Players can reconnect and reoffend without being blocked.

### Root Cause

In `BanUser()`, the `BanClient` call passes an empty string for the `command` parameter (the 6th argument, `_`):

```pawn
BanClient(cl, banDuration, BANFLAG_AUTO, reason, reason, _, _)
```

Per SourceMod's [`banning.inc`](https://sm.alliedmods.net/new-api/banning/BanClient):

> `command`: Command string to identify the source. **If this is left empty, then the OnBanClient forward will not be called.**

External ban systems (SQLiteBans, etc.) hook the `OnBanClient` global forward to intercept and record bans. Since `command` was empty, the forward was never fired, so these systems never saw the ban.

### Fix

Changed the `command` argument from `_` (empty) to `"stac"`, which is enough to trigger the `OnBanClient` forward:

```pawn
BanClient(cl, banDuration, BANFLAG_AUTO, reason, reason, "stac", _)
```

A comment is also added explaining why `command` must be non-empty.

### Scope

- Covers all detection types (bhop, fakeang, aimsnap, psilent, cmdnum, tbot, invalid_usercmd, cvar checks, misc checks) — they all route through `BanUser()`.
- The unauthenticated fallback path (`sm_addban`/`sm_banip`) already works because those commands internally call `BanClient` with a non-empty command string.
- No behavioral change on servers without SQLiteBans or similar hooking plugins — the `OnBanClient` forward simply has no handler, and SourceMod falls back to its default behavior (kick + banned.cfg).
- Does not affect the priority of other ban systems (SourceBans++, MaterialAdmin, GBans) which are checked first.